### PR TITLE
Replaced type "ip_addr" with "ip4_addr"

### DIFF
--- a/echo.c
+++ b/echo.c
@@ -20,7 +20,7 @@ extern volatile u8	Error;
 
 // Global Variables for Ethernet handling
 extern u16_t    	RemotePort;
-extern struct ip_addr  	RemoteAddr;
+extern struct ip4_addr  	RemoteAddr;
 extern struct udp_pcb 	send_pcb;
 
 int transfer_data() {
@@ -37,7 +37,7 @@ void print_app_header()
 
 /* recv_callback: function that handles responding to UDP packets */
 void recv_callback(void *arg, struct udp_pcb *upcb,
-                              struct pbuf *p, struct ip_addr *addr, u16_t port)
+                              struct pbuf *p, struct ip4_addr *addr, u16_t port)
 {
 
 	// Set up a timeout counter and a status variable

--- a/main.c
+++ b/main.c
@@ -51,11 +51,11 @@ volatile u8		Error;
 
 // Global Variables for Ethernet handling
 u16_t    		RemotePort = 8;
-struct ip_addr  	RemoteAddr;
+struct ip4_addr  	RemoteAddr;
 struct udp_pcb 		send_pcb;
 
 void
-print_ip(char *msg, struct ip_addr *ip) 
+print_ip(char *msg, struct ip4_addr *ip)
 {
 	print(msg);
 	xil_printf("%d.%d.%d.%d\n\r", ip4_addr1(ip), ip4_addr2(ip), 
@@ -80,7 +80,7 @@ void print_app_header()
 
 int main()
 {
-	struct ip_addr ipaddr, netmask, gw /*, Remotenetmask, Remotegw*/;
+	struct ip4_addr ipaddr, netmask, gw /*, Remotenetmask, Remotegw*/;
 	struct pbuf * psnd;
 	err_t udpsenderr;
 	int status = 0;


### PR DESCRIPTION
For this code to work with newer versions of Vitis the type has to be replaced. The original note by Lance Simms can be found [in chapter 3 part 1.2](https://lancesimms.com/Xilinx/MicroZed_UDP_Server_for_Waveform_Centroiding_Chapter3_Part1.html) of the original UDP server project.